### PR TITLE
Bug Fix: Accept empty dictionary instead of none as for request data

### DIFF
--- a/request_signer/tests/test_signed_request.py
+++ b/request_signer/tests/test_signed_request.py
@@ -150,7 +150,7 @@ class SignedRequestTests(test.TestCase):
 
         call_url = unquote(request.get_full_path())
         call_url = re.sub(r'&__signature={}$'.format(signature), '', call_url, count=1)
-        get_signature.assert_called_once_with(client.private_key, call_url, None)
+        get_signature.assert_called_once_with(client.private_key, call_url, {})
 
     @mock.patch('apysigner.get_signature')
     def test_calls_create_signature_properly_with_no_content_type(self, get_signature):
@@ -169,7 +169,7 @@ class SignedRequestTests(test.TestCase):
 
         call_url = unquote(request.get_full_path())
         call_url = re.sub(r'&__signature={}$'.format(signature), '', call_url, count=1)
-        get_signature.assert_called_once_with(client.private_key, call_url, None)
+        get_signature.assert_called_once_with(client.private_key, call_url, {})
 
     @mock.patch('apysigner.get_signature')
     def test_json_is_properly_parsed_into_signature(self, get_signature):

--- a/request_signer/validator.py
+++ b/request_signer/validator.py
@@ -57,5 +57,5 @@ class SignatureValidator(object):
         elif self.request.method.lower() in ['patch', 'put']:
             request_data = dict(QueryDict(self.request.body, encoding='utf-8'))
         else:
-            request_data = dict(self.request.POST) or None
+            request_data = dict(self.request.POST)
         return request_data

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-request-signer',
-    version='2.0.0',
+    version='2.0.1',
     author='imtapps',
     url='https://github.com/imtapps/django-request-signer',
     description="A python library for signing http requests.",


### PR DESCRIPTION
After intgrating this into multiple projects, it seems that the empty
dictionary may be the correct way to go