### PR TITLE
Bug/pip8

### DIFF
--- a/requirements/dist.txt
+++ b/requirements/dist.txt
@@ -2,4 +2,3 @@ django>1.7
 apysigner>3.0,<4.0
 generic-request-signer>1.0,<2.0
 six
-aloe

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@ nosexcover
 coverage
 lettuce
 flake8
+aloe

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-request-signer',
-    version='3.2.2',
+    version='3.2.3',
     author='imtapps',
     url='https://github.com/imtapps/django-request-signer',
     description="A python library for signing http requests.",


### PR DESCRIPTION
`aloe` is incompatible with pip8 because `repoze.lru` (a dependency) is incompatible.

This moves `aloe` into the testing requirements of which it is.